### PR TITLE
add transform to init

### DIFF
--- a/summit/strategies/gryffin.py
+++ b/summit/strategies/gryffin.py
@@ -92,10 +92,10 @@ class GRYFFIN(Strategy):
 
     """
 
-    def __init__(self, domain, save_dir=None, auto_desc_gen=False, sampling_strategies=4,
+    def __init__(self, domain, transform=None, save_dir=None, auto_desc_gen=False, sampling_strategies=4,
                  batches=1, logging=-1, parallel=True, boosted=True, sampler="uniform", softness=0.001,
                  continuous_optimizer="adam", categorical_optimizer="naive", discrete_optimizer="naive", **kwargs):
-        Strategy.__init__(self, domain)
+        Strategy.__init__(self, domain, transform=transform, **kwargs)
 
         self.domain_inputs = []
         self.domain_objectives = []


### PR DESCRIPTION
Transform is missing in `__init__` of Gryffin. This PR fixes that.