### PR TITLE
Categorical TSEMO

### DIFF
--- a/summit/domain.py
+++ b/summit/domain.py
@@ -262,6 +262,12 @@ class CategoricalVariable(Variable):
     """
 
     def __init__(self, name, description, **kwargs):
+        """
+
+        Returns
+        -------
+        object
+        """
         Variable.__init__(self, name, description, "categorical", **kwargs)
 
         # Get descriptors DataSet

--- a/summit/domain.py
+++ b/summit/domain.py
@@ -322,7 +322,7 @@ class CategoricalVariable(Variable):
         self._levels.append(level)
 
     def remove_level(self, level):
-        """Add a level to the discrete variable
+        """Remove a level from the discrete variable
 
         Parameters
         ---------
@@ -482,13 +482,6 @@ class Domain:
     def constraints(self):
         return self._constraints
 
-    # def __getitem__(self, key):
-    #     '''For accessing variables like a dictionary'''
-    #     for v in self.variables:
-    #         if v.name == key:
-    #             return v
-    #     raise KeyError(f'No variable {key} found in the domain.')
-
     # def _ipython_key_completions_(self):
     #     return [v.name for v in self.variables]
 
@@ -511,6 +504,30 @@ class Domain:
             else:
                 pass
         return output_variables
+
+    def get_categorical_combinations(self):
+        """Get all combinations of categoricals using full factorial design
+
+        Returns
+        -------
+        ds: DataSet
+            A dataset containing the combinations of all categorical cvariables.
+        """
+        levels = [
+            len(v.levels)
+            for v in self.input_variables
+            if v.variable_type == "categorical"
+        ]
+        doe = fullfact(levels)
+        i = 0
+        combos = {}
+        for v in self.input_variables:
+            if v.variable_type == "categorical":
+                indices = doe[:, i]
+                indices = indices.astype(int)
+                combos[v.name, "DATA"] = [v.levels[i] for i in indices]
+                i += 1
+        return DataSet(combos)
 
     def _raise_noncontinuous_outputs(self):
         """Raise an error if the outputs are not continuous variables"""
@@ -661,3 +678,42 @@ class Domain:
 
 class DomainError(Exception):
     pass
+
+
+def fullfact(levels):
+    """
+    Create a general full-factorial design
+
+    Parameters
+    ----------
+    levels : array-like
+        An array of integers that indicate the number of levels of each input
+        design factor.
+
+    Returns
+    -------
+    mat : 2d-array
+        The design matrix with coded levels 0 to k-1 for a k-level factor
+
+
+    Notes
+    ------
+    This code is copied from pydoe2: https://github.com/clicumu/pyDOE2/blob/master/pyDOE2/doe_factorial.py
+
+    """
+    n = len(levels)  # number of factors
+    nb_lines = np.prod(levels)  # number of trial conditions
+    H = np.zeros((nb_lines, n))
+
+    level_repeat = 1
+    range_repeat = np.prod(levels)
+    for i in range(n):
+        range_repeat //= levels[i]
+        lvl = []
+        for j in range(levels[i]):
+            lvl += [j] * level_repeat
+        rng = lvl * range_repeat
+        level_repeat *= levels[i]
+        H[:, i] = rng
+
+    return H

--- a/summit/strategies/base.py
+++ b/summit/strategies/base.py
@@ -95,6 +95,7 @@ class Transform:
         output_columns = []
         self.input_means, self.input_stds = {}, {}
         self.output_means, self.output_stds = {}, {}
+        self.encoders = {}
         for variable in self.domain.input_variables:
             if (
                 isinstance(variable, CategoricalVariable)
@@ -155,7 +156,7 @@ class Transform:
                     column_name = f"{variable.name}_{l}"
                     new_ds[column_name, "DATA"] = one_hot_values[:, loc]
                     input_columns.append(column_name)
-                variable.enc = enc
+                self.encoders[variable.name] = enc
 
                 # Drop old categorical column, then write as metadata
                 new_ds = new_ds.drop(variable.name, axis=1)
@@ -321,7 +322,7 @@ class Transform:
                 and categorical_method == "one-hot"
             ):
                 # Get one-hot encoder
-                enc = variable.enc
+                enc = self.encoders[variable.name]
 
                 # Get array to be transformed
                 one_hot_names = [f"{variable.name}_{l}" for l in variable.levels]

--- a/summit/strategies/base.py
+++ b/summit/strategies/base.py
@@ -268,6 +268,7 @@ class Transform:
                 isinstance(variable, CategoricalVariable)
                 and categorical_method == "descriptors"
             ):
+                var_descriptor_names = variable.ds.data_columns
                 # Unnormalize descriptors between 0 and 1
                 if min_max_scale_inputs:
                     for descriptor in var_descriptor_names:
@@ -278,7 +279,6 @@ class Transform:
                         )
 
                 # Add original categorical variable to the dataset
-                var_descriptor_names = variable.ds.data_columns
                 var_descriptor_conditions = ds[var_descriptor_names]
                 var_descriptor_orig_data = np.asarray(
                     [

--- a/summit/strategies/base.py
+++ b/summit/strategies/base.py
@@ -315,7 +315,7 @@ class Transform:
                 ]
                 for ixc in ix_code:
                     column_codes_2[ixc] = 1
-                new_ds.columns.set_codes(column_codes_2, level=1, inplace=True)
+                new_ds.columns = new_ds.columns.set_codes(column_codes_2, level=1)
             # Categorical variables using one-hot encoding
             elif (
                 isinstance(variable, CategoricalVariable)

--- a/summit/strategies/tsemo.py
+++ b/summit/strategies/tsemo.py
@@ -274,6 +274,10 @@ class TSEMO(Strategy):
 
     def _nsga_optimize(self, models):
         """NSGA-II optimization with categorical domains"""
+        from pymoo.algorithms.nsga2 import NSGA2
+        from pymoo.optimize import minimize
+        from pymoo.factory import get_termination
+
         optimizer = NSGA2(pop_size=self.pop_size)
         problem = TSEMOInternalWrapper(models, self.domain)
         termination = get_termination("n_gen", self.generations)

--- a/summit/strategies/tsemo.py
+++ b/summit/strategies/tsemo.py
@@ -8,6 +8,7 @@ from summit import get_summit_config_path
 
 from pymoo.model.problem import Problem
 
+from fastprogress.fastprogress import progress_bar
 from scipy.sparse import issparse
 import pathlib
 import os
@@ -303,7 +304,12 @@ class TSEMO(Strategy):
         X_list, y_list = [], []
 
         # Loop through all combinations of categoricals and run optimization
-        for _, combo in transformed_combos.iterrows():
+        bar = progress_bar(
+            transformed_combos.iterrows(),
+            total=transformed_combos.shape[0],
+            comment="NSGA Mixed Optimization",
+        )
+        for _, combo in bar:
             optimizer = NSGA2(pop_size=self.pop_size)
             problem = TSEMOInternalWrapper(
                 models, self.domain, fixed_variables=combo.to_dict()

--- a/summit/strategies/tsemo.py
+++ b/summit/strategies/tsemo.py
@@ -238,6 +238,7 @@ class TSEMO(Strategy):
         else:
             X, y = self._categorical_enumerate(models)
 
+        # Return if no suggestiosn found
         if X.shape[0] == 0 and y.shape[0] == 0:
             self.logger.warning("No suggestions found.")
             self.iterations += 1
@@ -305,11 +306,10 @@ class TSEMO(Strategy):
 
         # Loop through all combinations of categoricals and run optimization
         bar = progress_bar(
-            transformed_combos.iterrows(),
-            total=transformed_combos.shape[0],
-            comment="NSGA Mixed Optimization",
+            transformed_combos.iterrows(), total=transformed_combos.shape[0]
         )
         for _, combo in bar:
+            # bar.comment = "NSGA Mixed Optimization"
             optimizer = NSGA2(pop_size=self.pop_size)
             problem = TSEMOInternalWrapper(
                 models, self.domain, fixed_variables=combo.to_dict()

--- a/summit/strategies/tsemo.py
+++ b/summit/strategies/tsemo.py
@@ -294,7 +294,7 @@ class TSEMO(Strategy):
         from pymoo.factory import get_termination
 
         combos = self.categorical_combos
-        tranformed_combos = self._transform_categorical(combos)
+        transformed_combos = self._transform_categorical(combos)
 
         X_list, y_list = [], []
         # Loop through all combinations of categoricals and run optimization

--- a/summit/strategies/tsemo.py
+++ b/summit/strategies/tsemo.py
@@ -297,6 +297,7 @@ class TSEMO(Strategy):
         transformed_combos = self._transform_categorical(combos)
 
         X_list, y_list = [], []
+
         # Loop through all combinations of categoricals and run optimization
         for _, combo in transformed_combos.iterrows():
             optimizer = NSGA2(pop_size=self.pop_size)
@@ -329,11 +330,8 @@ class TSEMO(Strategy):
                 # Descriptor transformation
                 if self.use_descriptors and v.ds is not None:
                     transformed_values = v.ds.loc[values]
-
                     for col in transformed_values:
-                        transformed_combos[(col, "DATA")] = transformed_values[
-                            col
-                        ].tolist()
+                        transformed_combos[col] = transformed_values[col[0]].tolist()
                 elif self.use_descriptors and v.ds is None:
                     raise DomainError(
                         f"use_descriptors is true, but {v.name} has no descriptors."

--- a/summit/strategies/tsemo.py
+++ b/summit/strategies/tsemo.py
@@ -226,9 +226,7 @@ class TSEMO(Strategy):
 
         # NSGAII internal optimisation on spectrally sampled functions
         self.logger.info("Optimizing models using NSGAII.")
-        import pdb
 
-        pdb.set_trace()
         # Mixed domains
         if self.categorical_combos is not None and len(self.input_columns) > 0:
             X, y = self._nsga_optimize_mixed(models)

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,5 +1,6 @@
 from summit.domain import *
 from summit.utils.dataset import DataSet
+import pandas as pd
 import pytest
 
 
@@ -87,7 +88,6 @@ def test_categorical_variable():
     with pytest.raises(ValueError):
         var.remove_level("does_not_exist")
 
-
     # I should probably mock the dataset but I'm lazy
     solvent_ds = DataSet(
         [[5, 81], [-93, 111]],
@@ -149,16 +149,34 @@ def test_domain():
     )
     c = Constraint("flowrate_a+flowrate_b-100", "<=")
 
+    all_combos = DataSet(
+        [
+            ["potassium_hydroxide", "benzene"],
+            ["potassium_hydroxide", "toluene"],
+            ["sodium_hydroxide", "benzene"],
+            ["sodium_hydroxide", "toluene"],
+        ],
+        columns=["base", "solvent"],
+    )
+
     domain = Domain(variables=[var1, var2, var3, var4, var5, var6], constraints=[c])
     input_variables = [var1, var2, var3, var4, var5]
     assert domain.input_variables == input_variables
     assert domain.output_variables == [var6]
-    assert domain.num_variables() == 5 #not including outputs
+    assert domain.num_variables() == 5  # not including outputs
     assert domain.num_variables(include_outputs=True) == 6
-    assert domain.num_continuous_dimensions() == 3 #Not including outputs or descriptors 
+    assert (
+        domain.num_continuous_dimensions() == 3
+    )  # Not including outputs or descriptors
     assert domain.num_continuous_dimensions(include_outputs=True) == 4
     assert domain.num_continuous_dimensions(include_descriptors=True) == 5
-    assert domain.num_continuous_dimensions(include_outputs=True, include_descriptors=True) == 6
+    assert (
+        domain.num_continuous_dimensions(include_outputs=True, include_descriptors=True)
+        == 6
+    )
+    # Check that all combinations is correct()
+    domain_all_combos = domain.get_categorical_combinations()
+    assert pd.merge(all_combos, domain_all_combos, how="inner").equals(all_combos)
     assert domain.constraints == [c]
 
     # Test the adding feature
@@ -169,12 +187,17 @@ def test_domain():
     domain += c
     assert domain.input_variables == input_variables
     assert domain.output_variables == [var6]
-    assert domain.num_variables() == 5 #not including outputs
+    assert domain.num_variables() == 5  # not including outputs
     assert domain.num_variables(include_outputs=True) == 6
-    assert domain.num_continuous_dimensions() == 3 #Not including outputs or descriptors 
+    assert (
+        domain.num_continuous_dimensions() == 3
+    )  # Not including outputs or descriptors
     assert domain.num_continuous_dimensions(include_outputs=True) == 4
     assert domain.num_continuous_dimensions(include_descriptors=True) == 5
-    assert domain.num_continuous_dimensions(include_outputs=True, include_descriptors=True) == 6
+    assert (
+        domain.num_continuous_dimensions(include_outputs=True, include_descriptors=True)
+        == 6
+    )
     assert domain.constraints == [c]
 
     # Test sending wrong type

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -109,21 +109,23 @@ def test_runner_so_integration(strategy, experiment):
 @pytest.mark.parametrize(
     "experiment",
     [
-        get_pretrained_baumgartner_cc_emulator(include_cost=True),
         get_pretrained_reizman_suzuki_emulator(),
+        get_pretrained_baumgartner_cc_emulator(include_cost=True),
         DTLZ2,
         VLMOP2,
         SnarBenchmark,
     ],
 )
 def test_runner_mo_integration(strategy, experiment):
+    """Test Runner with multiobjective optimization strategies and benchmarks"""
     if not isinstance(experiment, ExperimentalEmulator):
         exp = experiment()
     else:
         exp = experiment
 
     if experiment.__class__.__name__ == "ReizmanSuzukiEmulator" and strategy not in [
-        SOBO
+        SOBO,
+        TSEMO,
     ]:
         # only run on strategies that work with categorical variables deireclty
         return


### PR DESCRIPTION
This PR fixes #130 by enabling optimization of mixed categorical and continuous domains in TSEMO. The `use_descriptors` keyword argument determines whether descriptors or one-hot encoding is used. Underneath the hood, we take a brute-force approach, running NSGA-II for every combination of categorical variables and then taking the best values as determined by hypervolume improvement.  There is also a refactor of some of the TSEMO code to make it easier to read.

Outside of TSEMO, this PR adds:
- a `get_categorical_combinations` to any domain, enabling you to get an exhaustive list of all the combinations of categorical variables.
- The ability to scale inputs to the min and max in the base `Transform` class.