### PR TITLE
Fix bug in hypervolume calculation for d>=3

### DIFF
--- a/summit/utils/multiobjective.py
+++ b/summit/utils/multiobjective.py
@@ -149,7 +149,7 @@ class _HyperVolume:
             hvRecursive = self.hvRecursive
             p = sentinel
             q = p.prev[dimIndex]
-            while q.cargo != None:
+            while q.cargo is not None:
                 if q.ignore < dimIndex:
                     q.ignore = 0
                 q = q.prev[dimIndex]


### PR DESCRIPTION
The hypervolume code was breaking for d>3 due to an error in checking for an empty list.