### PR TITLE
Add the ability to pass previous data runner

### DIFF
--- a/summit/run.py
+++ b/summit/run.py
@@ -127,6 +127,8 @@ class Runner:
 
         Parameters
         ----------
+        prev_res: DataSet, optional
+            Previous results to initialize the optimization
         save_freq : int, optional
             The frequency with which to checkpoint the state of the optimization. Defaults to None.
         save_at_end : bool, optional
@@ -146,7 +148,7 @@ class Runner:
         n_objs = len(self.experiment.domain.output_variables)
         fbest_old = np.zeros(n_objs)
         fbest = np.zeros(n_objs)
-        prev_res = None
+        prev_res = kwargs.get("prev_res")
         self.restarts = 0
 
         if kwargs.get("progress_bar", True):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -54,8 +54,9 @@ def test_runner_unit(max_iterations, batch_size, max_same, max_restarts, runner)
             pass
 
     exp = MockExperiment()
+    strategy = MockStrategy(exp.domain)
     r = runner(
-        strategy=MockStrategy(exp.domain),
+        strategy=strategy,
         experiment=exp,
         max_iterations=max_iterations,
         batch_size=batch_size,
@@ -76,6 +77,15 @@ def test_runner_unit(max_iterations, batch_size, max_same, max_restarts, runner)
 
     assert r.strategy.iterations == iterations
     assert r.experiment.data.shape[0] == int(batch_size * iterations)
+
+    # Check that reset works
+    r.reset()
+    assert r.experiment.data.shape[0] == 0
+
+    # Check that using previous data works
+    suggestions = strategy.suggest_experiments(num_experiments=10)
+    results = exp.run_experiments(suggestions)
+    r.run(prev_data=results)
 
 
 @pytest.mark.parametrize("strategy", [SOBO, SNOBFIT, NelderMead, Random, LHS])


### PR DESCRIPTION
This PR enables `Runner.run()` to take previous data. This is useful for cases where an algorithm is initialized with past data.