### PR TITLE
Fix bug where prev_res was not actually working

### DIFF
--- a/summit/run.py
+++ b/summit/run.py
@@ -157,7 +157,7 @@ class Runner:
             bar = range(self.max_iterations)
         for i in bar:
             # Get experiment suggestions
-            if i == 0:
+            if i == 0 and prev_res is None:
                 k = self.n_init if self.n_init is not None else self.batch_size
                 next_experiments = self.strategy.suggest_experiments(num_experiments=k)
             else:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -83,9 +83,12 @@ def test_runner_unit(max_iterations, batch_size, max_same, max_restarts, runner)
     assert r.experiment.data.shape[0] == 0
 
     # Check that using previous data works
-    suggestions = strategy.suggest_experiments(num_experiments=10)
+    r.strategy.iterations = 0
+    suggestions = r.strategy.suggest_experiments(num_experiments=10)
     results = exp.run_experiments(suggestions)
-    r.run(prev_data=results)
+    r.run(prev_res=results)
+    assert r.strategy.iterations == iterations + 1
+    assert r.experiment.data.shape[0] == int(batch_size * iterations + 10)
 
 
 @pytest.mark.parametrize("strategy", [SOBO, SNOBFIT, NelderMead, Random, LHS])


### PR DESCRIPTION
The `prev_res` keyword in `Runner.run` was not actually working.