### PR TITLE
Better CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,8 @@ jobs:
     - name: Install summit and pytest
       shell: bash
       run: |
-        pip install summit-*.whl[experiments] pytest
+        WHL_NAME=$(ls summit-*.whl)
+        pip install ${WHL_NAME}[experiments] pytest
 
     - name: Run tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,9 @@ jobs:
   # Run pytest using built package
   test:
     needs: build
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
         python: ["3.8", "3.9"]
 
     steps:
@@ -65,7 +64,7 @@ jobs:
       shell: bash
       run: |
         WHL_NAME=$(ls summit-*.whl)
-        pip install ${WHL_NAME}[experiments,entmoot] pytest
+        pip install ${WHL_NAME}[experiments] pytest
 
     - name: Run tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,7 @@ jobs:
     - name: Install summit and pytest
       shell: bash
       run: |
-        pip install summit-*.tar.gz -e experiments
-        pip install pytest
+        pip install summit-*.tar.gz[experiments] pytest
 
     - name: Run tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,9 @@ jobs:
     
     - name: Install summit and pytest
       shell: bash
-      run: pip install summit-*.tar.gz pytest
+      run: |
+        pip install summit-*.tar.gz -e experiments
+        pip install pytest
 
     - name: Run tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       shell: bash
       run: |
         WHL_NAME=$(ls summit-*.whl)
-        pip install ${WHL_NAME}[experiments] pytest
+        pip install ${WHL_NAME}[experiments,entmoot] pytest
 
     - name: Run tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       shell: bash
       run: |
         WHL_NAME=$(ls summit-*.whl)
-        pip install ${WHL_NAME}[experiments] pytest
+        pip install ${WHL_NAME}[experiments,entmoot] pytest
 
     - name: Run tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install summit and pytest
       shell: bash
       run: |
-        pip install summit-*.tar.gz[experiments] pytest
+        pip install summit-*.whl[experiments] pytest
 
     - name: Run tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Test & Publish
+name: Test and Publish
 on:
   push:
   pull_request:
@@ -10,8 +10,8 @@ on:
     - '**:**'
 
 jobs:
-  #Run pytest and build package
-  test_build:
+  # Build the package
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -21,62 +21,132 @@ jobs:
     - name: Install python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
 
     - name: Install poetry
-      uses: Gr1N/setup-poetry@v4
+      uses: Gr1N/setup-poetry@v7
 
-    - name: Cache poetry dependencies
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pypoetry/virtualenvs
-        key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-poetry-
-    
-    - name: Install dependencies
-      run: poetry install -E experiments -E entmoot
-
-    - name: Run pytest
-      run: poetry run pytest --doctest-modules --ignore=experiments --disable-warnings
-
-    # Check that the build process works correctly
     - name: Build package
       run: poetry build
-  
+
+    - name: Upload built package
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: dist/
+        retention-days: 1
+
+  # Run pytest using built package
+  test:
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python: ["3.8", "3.9"]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+        cache: 'pip'
+        cache-dependency-path: "poetry.lock"
+
+    - name: Download built package
+      uses: actions/download-artifact@v3
+      with:
+        name: dist
+    
+    - name: Install summit and pytest
+      shell: bash
+      run: pip install summit-*.tar.gz pytest
+
+    - name: Run tests
+      shell: bash
+      run: summit-tests
+
   # Publish to pypi on version change
+  # This is based on https://github.com/coveooss/pypi-publish-with-poetry
   publish:
-   needs: test_build
-   runs-on: ubuntu-latest
+    needs: test
+    runs-on: ubuntu-latest
 
-   steps:
-   - uses: actions/checkout@v2
-     with:
-       # Make sure to fetch the last two commits
-       # Needed forthe version bump and tag
-       fetch-depth: 2
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
 
-   - name: Install python
-     uses: actions/setup-python@v2
-     with:
-       python-version: '3.8'
+    - name: Install python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
 
-   - name: Install poetry
-     uses: Gr1N/setup-poetry@v4
+    - name: Download built package
+      uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist/
 
-   - name: Install toml
-     run: pip install toml
+    - name: Install poetry
+      uses: Gr1N/setup-poetry@v7
 
-   - name: Check for version bump and tag
-     id: version_check
-     uses: salsify/action-detect-and-tag-new-version@v2
-     with:
-       tag-template: "{VERSION}"
-       create-tag: ${{ github.ref == 'refs/heads/master' }} # only create new tag on master
-       version-command: |
-         python get_version.py
+    - name: Install coveo-pypi-cli
+      run: pip install coveo-pypi-cli
 
-   - name: Publish
-     # Only publish if there is a new tag
-     if: ${{ steps.version_check.tag }}
-     run: poetry publish --build -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }}
+    - name: Determine the version for this release from the build
+      id: current
+      run: |
+        BUILD_VER="$(ls dist/summit-*.tar.gz)"
+        echo "Path: $BUILD_VER"
+        if [[ $BUILD_VER =~ (summit-)([^,][0-9.]{4}) ]]; then
+            echo "::set-output name=version::${BASH_REMATCH[2]}"
+            echo "Version of build: ${BASH_REMATCH[2]}"
+        else
+            echo "No version found found"
+        fi
+        
+    - name: Get latest published version
+      id: published
+      run: |
+        PUB_VER="$(pypi current-version summit)"
+        echo "::set-output name=version::$PUB_VER"
+        echo "Latest published version: $PUB_VER"
+    
+
+    - name: Publish to pypi if new version
+      if: (steps.current.outputs.version != steps.published.outputs.version)
+      shell: bash
+      run: |
+        poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+        if [[ '${{ github.ref_name }}' == 'master' ]]; then
+          poetry publish 
+        else
+          echo "Dry run of publishing the package"
+          poetry publish --dry-run
+        fi
+
+    - name: Tag repository
+      shell: bash
+      id: get-next-tag
+      if: (steps.current.outputs.version != steps.published.outputs.version)
+      run: |
+        TAG_NAME=${{ steps.current.outputs.version }}
+        echo "::set-output name=tag-name::$TAG_NAME"
+        echo "This release will be tagged as $TAG_NAME"
+        git config user.name "github-actions"
+        git config user.email "actions@users.noreply.github.com"
+        git tag --annotate --message="Automated tagging system" $TAG_NAME ${{ github.sha }}
+
+    - name: Push the tag
+      if: (steps.current.outputs.version != steps.published.outputs.version)
+      env:
+        TAG_NAME: ${{ steps.current.outputs.version }}
+      run: |
+        if [[ ${{ github.ref_name }} == 'master' ]]; then
+          git push origin $TAG_NAME
+        else
+          echo "If this was the master branch, I would push a new tag named $TAG_NAME"
+        fi

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,6 +1,8 @@
 Installation
 ============
 
+Note that Summit only works with python 3.8 and 3.9 currently. We are waiting on pytorch to add python 3.10 support.
+
 The easiest way to install Summit is using pip or a depedency manager that supports pip:
 
 
@@ -55,11 +57,14 @@ Notes about installing on Apple M1
 You might run into some issues when installing scientific python packages such as Summit on Apple M1. Follow the steps below to install via pip:
 
 .. code-block:: bash
+    
     arch -arm64 brew install llvm@11 
     brew install hdf5
     HDF5_DIR=/opt/homebrew/opt/hdf5 PIP_NO_BINARY="h5py" LLVM_CONFIG="/opt/homebrew/Cellar/llvm@11/11.1.0_3/bin/llvm-config" arch -arm64 poetry install
 
-More resources
+If this commnad fails, make sure to check the version of LLVM that was actually installed (i.e., run `ls /opt/homebrew/Cellar/llvm@11/`) and replace 11.1.0_3 in the third line above with the correct version.   
+
+More resources:
 
 * [LLVM isssue](https://github.com/numba/llvmlite/issues/693#issuecomment-909501195)
 * [Installing H5py (for numpy)](https://docs.h5py.org/en/stable/build.html#custom-installation)

--- a/get_version.py
+++ b/get_version.py
@@ -1,8 +1,0 @@
-import toml
-
-with open("pyproject.toml", "r") as f:
-    text = f.read()
-
-toml_dict = toml.loads(text)
-
-print(toml_dict["tool"]["poetry"]["version"])

--- a/summit/__init__.py
+++ b/summit/__init__.py
@@ -21,3 +21,15 @@ from summit.strategies import *
 from summit.benchmarks import *
 from summit.utils.dataset import DataSet
 from summit.utils.multiobjective import pareto_efficient, hypervolume
+
+
+def run_tests():
+    """Run tests using pytest"""
+    import pytest
+    from pytest import ExitCode
+    import sys
+
+    retcode = pytest.main(
+        ["--doctest-modules", "--disable-warnings", "--pyargs", "summit"]
+    )
+    sys.exit(retcode)


### PR DESCRIPTION
**Problem**: Publishing this project to pypi was manual, meaning I rarely published updates. Furthermore, things were breaking on different versions of python and different operating systems.

**Solution**:
- Separate build step prior to testing and publishing
-  Matrix testing across multiple python versions (3.8 and 3.9)
-  New GH action for publishing to pypi automatically based on version increments in pyproject.toml

Also adds back the `run_tests` function that I forgot in #176 