### PR TITLE
Change Pandas append to concat

### DIFF
--- a/summit/experiment.py
+++ b/summit/experiment.py
@@ -87,9 +87,9 @@ class Experiment(ABC):
         for i, condition in conditions.iterrows():
             start = time.time()
             res, extras = self._run(condition, **kwargs)
-            # res = add_metadata_columns(res, conditions[conditions.metadata_columns])
             experiment_time = time.time() - start
-            self._data = self._data.append(res)
+            res = DataSet(res).T
+            self._data = pd.concat([self._data, res], axis=0)
             self._data["experiment_t"].iat[-1] = float(experiment_time)
             self._data["computation_t"].iat[-1] = float(diff)
             if condition.get("strategy") is not None:

--- a/summit/strategies/multitask.py
+++ b/summit/strategies/multitask.py
@@ -6,7 +6,7 @@ from summit.utils.dataset import DataSet
 from botorch.acquisition import ExpectedImprovement as EI
 
 # from botorch.acquisition import qExpectedImprovement as qEI
-
+import pandas as pd
 import numpy as np
 from typing import Type, Tuple, Union, Optional
 
@@ -407,7 +407,7 @@ class STBO(Strategy):
         elif prev_res is not None and self.all_experiments is None:
             self.all_experiments = prev_res
         elif prev_res is not None and self.all_experiments is not None:
-            self.all_experiments = self.all_experiments.append(prev_res)
+            self.all_experiments = pd.concat([self.all_experiments, prev_res], axis=0)
         self.iterations += 1
         data = self.all_experiments
 
@@ -481,7 +481,7 @@ class STBO(Strategy):
         """Reset MTBO state"""
         self.all_experiments = None
         self.iterations = 0
-        
+
     @staticmethod
     def standardize(X):
         mean, std = X.mean(), X.std()

--- a/summit/strategies/tsemo.py
+++ b/summit/strategies/tsemo.py
@@ -178,7 +178,7 @@ class TSEMO(Strategy):
         elif prev_res is not None and self.all_experiments is None:
             self.all_experiments = prev_res
         elif prev_res is not None and self.all_experiments is not None:
-            self.all_experiments = self.all_experiments.append(prev_res)
+            self.all_experiments = pd.concat([self.all_experiments, prev_res], axis=0)
 
         if self.all_experiments.shape[0] <= 3:
             lhs = LHS(self.domain, categorical_method=cat_method)
@@ -210,7 +210,10 @@ class TSEMO(Strategy):
             # Training
             models[i] = ThompsonSampledModel(v.name)
             train_results[i] = models[i].fit(
-                inputs, outputs[[v.name]], n_retries=self.n_retries, n_spectral_points=self.n_spectral_points,
+                inputs,
+                outputs[[v.name]],
+                n_retries=self.n_retries,
+                n_spectral_points=self.n_spectral_points,
             )
 
             # Evaluate spectral sampled functions
@@ -582,7 +585,7 @@ class ThompsonSampledModel:
         )
 
     def predict(self, X: DataSet, **kwargs):
-        """Predict the values of a """
+        """Predict the values of a"""
         X = X[self.input_columns_ordered].to_numpy()
         return self.rff(X)
 


### PR DESCRIPTION
Pandas append has been deprecated in favor of pandas concat (see [here](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.4.0.html#deprecated-dataframe-append-and-series-append)). This PR replaces those problems.