### PR TITLE
Ensure dtype float to input

### DIFF
--- a/summit/strategies/sobo.py
+++ b/summit/strategies/sobo.py
@@ -306,7 +306,7 @@ class SOBO(Strategy):
                             inputs[v.name], v.levels
                         )
 
-            inputs = inputs.to_numpy()
+            inputs = inputs.to_numpy().astype(float)
             outputs = outputs.to_numpy()
 
             if self.prev_param is not None:


### PR DESCRIPTION
Trying the `test_sobo_thc` function from `experiments/visualize_ThreeHumpCamel.py` I got this error:

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
AttributeError: 'float' object has no attribute 'rint'

The above exception was the direct cause of the following exception:

TypeError                                 Traceback (most recent call last)
File [~/.venv/lib/python3.10/site-packages/numpy/core/fromnumeric.py:57](https://file+.vscode-resource.vscode-cdn.net/home/ilario/software/summit/experiments/~/.venv/lib/python3.10/site-packages/numpy/core/fromnumeric.py:57), in _wrapfunc(obj, method, *args, **kwds)
     56 try:
---> 57     return bound(*args, **kwds)
     58 except TypeError:
     59     # A TypeError occurs if the object does have such a method in its
     60     # class, but its signature is not identical to that of NumPy's. This
   (...)
     64     # Call _wrapit from within the except clause to ensure a potential
     65     # exception has a traceback chain.

TypeError: loop of ufunc does not support argument 0 of type float which has no callable rint method

During handling of the above exception, another exception occurred:

AttributeError                            Traceback (most recent call last)
AttributeError: 'float' object has no attribute 'rint'

The above exception was the direct cause of the following exception:

TypeError                                 Traceback (most recent call last)
Cell In[3], line 1
----> 1 test_sobo_thc(4, True, None, plot=True)

File [~/software/summit/experiments/visualize_ThreeHumpCamel.py:190](https://file+.vscode-resource.vscode-cdn.net/home/ilario/software/summit/experiments/~/software/summit/experiments/visualize_ThreeHumpCamel.py:190), in test_sobo_thc(num_experiments, maximize, constraint, plot)
    187     print(next_experiments)  # show next experiments
    188     print("\n")
--> 190 xbest = np.around(xbest, decimals=3)
    191 fbest = np.around(fbest, decimals=3)
    192 print("Optimal setting: " + str(xbest) + " with outcome: " + str(fbest))

File <__array_function__ internals>:180, in around(*args, **kwargs)

File [~/.venv/lib/python3.10/site-packages/numpy/core/fromnumeric.py:3348](https://file+.vscode-resource.vscode-cdn.net/home/ilario/software/summit/experiments/~/.venv/lib/python3.10/site-packages/numpy/core/fromnumeric.py:3348), in around(a, decimals, out)
   3257 @array_function_dispatch(_around_dispatcher)
   3258 def around(a, decimals=0, out=None):
   3259     """
   3260     Evenly round to the given number of decimals.
   3261 
   (...)
   3346 
   3347     """
-> 3348     return _wrapfunc(a, 'round', decimals=decimals, out=out)

File [~/.venv/lib/python3.10/site-packages/numpy/core/fromnumeric.py:66](https://file+.vscode-resource.vscode-cdn.net/home/ilario/software/summit/experiments/~/.venv/lib/python3.10/site-packages/numpy/core/fromnumeric.py:66), in _wrapfunc(obj, method, *args, **kwds)
     57     return bound(*args, **kwds)
     58 except TypeError:
     59     # A TypeError occurs if the object does have such a method in its
     60     # class, but its signature is not identical to that of NumPy's. This
   (...)
     64     # Call _wrapit from within the except clause to ensure a potential
     65     # exception has a traceback chain.
---> 66     return _wrapit(obj, method, *args, **kwds)

File [~/.venv/lib/python3.10/site-packages/numpy/core/fromnumeric.py:43](https://file+.vscode-resource.vscode-cdn.net/home/ilario/software/summit/experiments/~/.venv/lib/python3.10/site-packages/numpy/core/fromnumeric.py:43), in _wrapit(obj, method, *args, **kwds)
     41 except AttributeError:
     42     wrap = None
---> 43 result = getattr(asarray(obj), method)(*args, **kwds)
     44 if wrap:
     45     if not isinstance(result, mu.ndarray):

TypeError: loop of ufunc does not support argument 0 of type float which has no callable rint method
```

The problem seems to be that the `dtype` of a variable was `object` and numpy didn't like that.
For fixing this issue would have been enough to fix it here:

https://github.com/sustainable-processes/summit/blob/c3deffc90aad5573c32de2968ba26d95e3ccaf5a/summit/strategies/sobo.py#L316

But for staying safe, I corrected it in the previous definition of the `input` variable.