### PR TITLE
Change GH actions wf so it runs on forked PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,11 @@
 name: Test and Publish
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
-      # Branches from forks have the form 'user:branch-name' so we only run
-      # this job on pull_request events for branches that look like fork
-      # branches. Without this we would end up running this job twice for non
-      # forked PRs, once for the push and then once for opening the PR.
-    - '**:**'
+      - main
 
 jobs:
   # Build the package


### PR DESCRIPTION
Currently, the Github actions workflow won't run on pull requests from forked repos. This should fix that.