### PR TITLE
Increase num improve iterations for SOBO

### DIFF
--- a/summit/tests/test_strategies.py
+++ b/summit/tests/test_strategies.py
@@ -544,7 +544,7 @@ def test_nm3D(maximize, x_start, constraint, plot=False):
     ],
 )
 def test_sobo(
-    batch_size, max_num_exp, maximize, constraint, test_num_improve_iter=15, plot=False
+    batch_size, max_num_exp, maximize, constraint, test_num_improve_iter=50, plot=False
 ):
     hartmann3D = Hartmann3D(maximize=maximize, constraints=constraint)
     strategy = SOBO(domain=hartmann3D.domain, kernel=GPy.kern.Matern32(3))


### PR DESCRIPTION
This is to prevent the SOBO tests from failing by increasing the number of iterations it can go without improvement.